### PR TITLE
Fixed f-score computation for beta != 1.

### DIFF
--- a/bcubed/__init__.py
+++ b/bcubed/__init__.py
@@ -12,4 +12,4 @@ from bcubed.extended import recall
 
 def fscore(p_val, r_val, beta=1.0):
     """Computes the F_{beta}-score of given precision and recall values."""
-    return (1.0 + beta) * (p_val * r_val / (beta**2 * p_val + r_val))
+    return (1.0 + beta**2) * (p_val * r_val / (beta**2 * p_val + r_val))


### PR DESCRIPTION
Addresses [1](https://github.com/hhromic/python-bcubed/issues/1l).

The bcubed.fscore function is incorect

It is currently computed as
`(1.0 + beta) * (p_val * r_val / (beta**2 * p_val + r_val))`
while it should be
`(1.0 + beta**2) * (p_val * r_val / (beta**2 * p_val + r_val))`
